### PR TITLE
Add type-kit to marketing pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,4 +10,5 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require typekit
 //= require_tree .

--- a/app/assets/javascripts/typekit.js
+++ b/app/assets/javascripts/typekit.js
@@ -1,0 +1,7 @@
+(function(d) {
+  var config = {
+    kitId: 'xhk0shy',
+    scriptTimeout: 3000
+  },
+  h=d.documentElement,t=setTimeout(function(){h.className=h.className.replace(/\bwf-loading\b/g,"")+" wf-inactive";},config.scriptTimeout),tk=d.createElement("script"),f=false,s=d.getElementsByTagName("script")[0],a;h.className+=" wf-loading";tk.src='//use.typekit.net/'+config.kitId+'.js';tk.async=true;tk.onload=tk.onreadystatechange=function(){a=this.readyState;if(f||a&&a!="complete"&&a!="loaded")return;f=true;clearTimeout(t);try{Typekit.load(config)}catch(e){}};s.parentNode.insertBefore(tk,s)
+})(document);

--- a/app/assets/stylesheets/element.sass
+++ b/app/assets/stylesheets/element.sass
@@ -1,6 +1,12 @@
 body
-  font-family: 'Open Sans', sans-serif
+  font-family: 'brandon-grotesque', serif
   color: $bd-dk-blue
+
+.wf-loading
+  visibility: hidden
+
+.wf-active
+  visibility: visible
 
 h1
   font-size: 36px

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,6 @@
   <%= javascript_include_tag 'application', 'data-turbolinks-track' => true %>
   <%= csrf_meta_tags %>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
-  <link href='http://fonts.googleapis.com/css?family=Open+Sans:400,300' rel='stylesheet' type='text/css'>
 </head>
 <body>
   <%= render partial: 'layouts/nav' %>


### PR DESCRIPTION
@rockwood I wasn't sure where the best place to put the .js from Typekit would be. Would vendor make more sense? It's a snippet from their site. 
